### PR TITLE
chore(codespaces): tailor devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:0-18
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres
+{
+	"name": "Starter Kit v2",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// This can be used to network with other containers or with the host.
+	"forwardPorts": [3000, 26257, 8080],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm install && sed s/SESSION_SECRET=random_session_secret/SESSION_SECRET=`npx uuid`/ .env.example > .env.development.local && export $(grep DATABASE_URL .env.development.local | xargs) && npm run migrate"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  app:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+      
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:cockroachdb
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  cockroachdb:
+    extends:
+      file: ../docker-compose.yml
+      service: cockroachdb
+
+volumes:
+  cockroach-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - COCKROACH_DATABASE=app
       - COCKROACH_USER=root
     volumes:
-      - cockroach-volume:/cockroach/cockroach-data"
+      - cockroach-volume:/cockroach/cockroach-data
     command: start-single-node --insecure
 
 volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "starter-kit-v2-kr",
+  "name": "starter-kit-v2",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "starter-kit-v2-kr",
+      "name": "starter-kit-v2",
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "starter-kit-v2-kr",
+  "name": "starter-kit-v2",
   "version": "0.0.0",
   "private": true,
   "scripts": {
     "generate": "prisma generate",
-    "db:setup": "docker compose -f \"docker-compose.yaml\" up -d --wait",
+    "db:setup": "docker compose -f \"docker-compose.yml\" up -d --wait",
     "db:sleep": "sleep 3",
     "db:seed": "prisma db seed",
     "db:reset": "prisma migrate reset",


### PR DESCRIPTION
## Problem

We want to make the developer experience as smooth as possible. 
Doing everything from within the browser or at least an environment we can control on the user's behalf is an added bonus

## Solution

- Add config for a CodeSpace devcontainer specific to Starter Kit
  - Take the trouble to run a post-create command to `npm i`, prep an env file and run `prisma migrate deploy`
- Tidy up file and package names while we are here

## Testing

Use https://github.com/codespaces/new?hide_repo_select=true&ref=chore%2Fcodespaces%2Fdevcontainer&repo=610561263
