### PR TITLE
feat: add migration for better indexes

### DIFF
--- a/prisma/migrations/20230420051446_better_indexes/migration.sql
+++ b/prisma/migrations/20230420051446_better_indexes/migration.sql
@@ -1,0 +1,23 @@
+-- DropIndex
+DROP INDEX "LikedPosts_post_id_idx";
+
+-- DropIndex
+DROP INDEX "LikedPosts_user_id_idx";
+
+-- DropIndex
+DROP INDEX "Post_author_id_idx";
+
+-- DropIndex
+DROP INDEX "ReadPosts_user_id_idx";
+
+-- CreateIndex
+CREATE INDEX "Post_parent_post_id_idx" ON "Post"("parent_post_id");
+
+-- CreateIndex
+CREATE INDEX "Post_parent_post_id_deleted_at_id_idx" ON "Post"("parent_post_id", "deleted_at", "id");
+
+-- CreateIndex
+CREATE INDEX "Post_deleted_at_idx" ON "Post"("deleted_at");
+
+-- CreateIndex
+CREATE INDEX "Post_created_at_idx" ON "Post"("created_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,7 +46,10 @@ model Post {
   updatedAt DateTime  @default(now()) @updatedAt @map("updated_at")
   deletedAt DateTime? @map("deleted_at") @db.Timestamp
 
-  @@index([authorId])
+  @@index([parentPostId])
+  @@index([parentPostId, deletedAt, id])
+  @@index([deletedAt])
+  @@index([createdAt])
 }
 
 model ReadPosts {
@@ -58,7 +61,6 @@ model ReadPosts {
 
   @@id([postId, userId])
   @@index([postId])
-  @@index([userId])
 }
 
 model LikedPosts {
@@ -69,8 +71,6 @@ model LikedPosts {
   createdAt DateTime @default(now()) @map("created_at")
 
   @@id([postId, userId])
-  @@index([postId])
-  @@index([userId])
 }
 
 model User {


### PR DESCRIPTION
CockroachDB very nice, give insights as to what indexes we can use to improve perf. However, Prisma current does not support [`STORING` clause](https://www.cockroachlabs.com/docs/stable/indexes.html#storing-columns) (i.e. `INCLUDE` clause in postgres), see https://github.com/prisma/prisma/issues/8584, so for now just use the normal indexes.

This PR adds better indices that fits our current app's access patterns. 
Probably can add into our CockroachDB readme docs also in future PRs when we write about why we chose cockroachDB, about its features, etc.